### PR TITLE
Bump httpclient from 4.5.6 to 4.5.13 in /nuxhash/nhrest/java

### DIFF
--- a/nuxhash/nhrest/java/pom.xml
+++ b/nuxhash/nhrest/java/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.6</version>
+      <version>4.5.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.5.6 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:production ...